### PR TITLE
change sas to saspath

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,5 +24,5 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/R/sascfg.R
+++ b/R/sascfg.R
@@ -5,7 +5,7 @@
 #'
 #' @param name (`character`)\cr name of the configuration.
 #' @param host (`character`)\cr host name of remote server.
-#' @param sas (`character`)\cr SAS executable path on remote server.
+#' @param saspath (`character`)\cr SAS executable path on remote server.
 #' @param ssh (`character`)\cr executable path of ssh.
 #' @param encoding (`character`)\cr encoding of the SAS session.
 #' @param ... additional arguments.
@@ -14,13 +14,13 @@
 #'
 #' @export
 #' @details
-#' `host` and `sas` are required to connect to remote SAS server. Other arguments can follow default.
+#' `host` and `saspath` are required to connect to remote SAS server. Other arguments can follow default.
 #' If transferring datasets is needed, then tunnelling is required.
 #' Use `tunnel = `, `rtunnel = ` to specify tunnels and reverse tunnels.
 #' The values should be length 1 integer.
-sascfg <- function(name = "default", host, sas, ssh = system("which ssh", intern = TRUE),
+sascfg <- function(name = "default", host, saspath, ssh = system("which ssh", intern = TRUE),
                    encoding = "latin1", options = list("-fullstimer"), ..., sascfg = "sascfg_personal.py") {
-  lst <- list(host = host, sas = sas, ssh = ssh, encoding = encoding, options = options)
+  lst <- list(host = host, saspath = saspath, ssh = ssh, encoding = encoding, options = options)
   lst <- c(lst, list(...))
   check_list(lst, types = c("character", "integer"), names = "named")
   f <- file(sascfg, "w")

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ After the installation completes, you are ready to use `sasr` package.
 To use `sasr`, you need to follow these steps
 
 1. Configure your SAS server in `sascfg_personal.py` under your working directory or the home directory. This is the default file that `sasr` will look at. However, you can still change that through `options(sascfg = )`, then `sasr` will try to find any name that is available in your specified option.
-    1. If you don't know how to create this file, use `sascfg()` to create the file. Required arguments include `host` and `sas`.
+    1. If you don't know how to create this file, use `sascfg()` to create the file. Required arguments include `host` and `saspath`.
         1. `sascfg()` only creates ssh based SAS session.
         1. Only password-less ssh connection is supported, e.g. ssh via public keys.
         1. `host` is the hostname of the SAS server.
-        1. `sas` is the SAS executable path on the SAS server.
+        1. `saspath` is the SAS executable path on the SAS server.
         1. Other arguments are added to the configuration file directly.
         1. `tunnel` and `rtunnel` are required if you want to transfer datasets between R and SAS. Use integers like `tunnel = 9999L` in R, or modify `sascfg_personal.py` to make sure they are integers.
     1. You can create the configuration by yourself and then SAS connection will not be restricted to ssh.

--- a/man/sascfg.Rd
+++ b/man/sascfg.Rd
@@ -7,7 +7,7 @@
 sascfg(
   name = "default",
   host,
-  sas,
+  saspath,
   ssh = system("which ssh", intern = TRUE),
   encoding = "latin1",
   options = list("-fullstimer"),
@@ -20,7 +20,7 @@ sascfg(
 
 \item{host}{(\code{character})\cr host name of remote server.}
 
-\item{sas}{(\code{character})\cr SAS executable path on remote server.}
+\item{saspath}{(\code{character})\cr SAS executable path on remote server.}
 
 \item{ssh}{(\code{character})\cr executable path of ssh.}
 
@@ -37,7 +37,7 @@ sascfg(
 Create SAS session configuration file based on argument.
 }
 \details{
-\code{host} and \code{sas} are required to connect to remote SAS server. Other arguments can follow default.
+\code{host} and \code{saspath} are required to connect to remote SAS server. Other arguments can follow default.
 If transferring datasets is needed, then tunnelling is required.
 Use \verb{tunnel = }, \verb{rtunnel = } to specify tunnels and reverse tunnels.
 The values should be length 1 integer.

--- a/tests/testthat/test-sascfg.R
+++ b/tests/testthat/test-sascfg.R
@@ -3,7 +3,7 @@
 test_that("sascfg creates sas configuration file", {
   skip_if_not(py_available(TRUE))
   tmpf <- tempfile()
-  sascfg(ssh = "ssh", sas = "sas", host = "test.com", sascfg = tmpf)
+  sascfg(ssh = "ssh", saspath = "sas", host = "test.com", sascfg = tmpf)
   on.exit(unlink(tmpf))
   expect_file_exists(tmpf)
 })


### PR DESCRIPTION
This should fix #20
Has this ever worked with 'sas' in the config file? I couldn't see that this parameter was changed in the SASPy changelog... so I don't know if this should be version dependent somehow.